### PR TITLE
Forcing build of latest KubOS source

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,5 @@
 
 git clone https://github.com/kubos/kubos-linux-build
 cd kubos-linux-build
+sed -i '/BR2_KUBOS_VERSION/c\BR2_KUBOS_VERSION = "master"' configs/${KUBOS_BOARD}_defconfig
 ./build.sh


### PR DESCRIPTION
With kubos/kubos-linux-build#205 we are now version locking the KubOS source.

We want to still get a heads up of any upcoming incompatibilities, so this PR updates the delivery build script to force the build to use the master branch of the main kubos repo